### PR TITLE
Update laravel/nova requirement from 3.6.* to 3.7.* (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Breadcrumbs for Laravel Nova
 [![License](https://badgen.net/packagist/license/chris-ware/nova-breadcrumbs)](ttps://packagist.org/packages/chris-ware/nova-breadcrumbs)
 [![StyleCI](https://github.styleci.io/repos/160367785/shield?branch=master)](https://github.styleci.io/repos/160367785)
 
-Current Supported Nova Version: **3.6**  
+Current Supported Nova Version: **3.7**  
 
 As new versions of Nova are released, if changes are made to any of the views that this package has to overwrite, a new version will need to be released. Composer version constraints should prevent installs on versions that aren't supported.
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": "3.6.*"
+        "laravel/nova": "3.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* Update laravel/nova requirement from 3.6.* to 3.7.*

Updates the requirements on laravel/nova to permit the latest version.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* Add support for 3.7

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>
Co-authored-by: Chris Ware | morphsites <chris.ware@morphsites.com>

## Before creating a pull request!

If you are creating a pull request simply to change the supported version of Nova, STOP! Read the readme first, and understand what you actually need to do and why the version constraint is in the package in the first place.

If you do want to assist by updating this package for a newer version of Nova, then you will need to ensure that it is correctly version locked, the readme has been updated and the assets have been recompiled using the ```build/production.sh``` file.

Aside from the above, fixes and enhancements are always welcome.